### PR TITLE
Update DocumentsUI overlay for Oreo

### DIFF
--- a/overlay/common/packages/apps/DocumentsUI/res/values/config.xml
+++ b/overlay/common/packages/apps/DocumentsUI/res/values/config.xml
@@ -18,6 +18,6 @@
 
     <!-- Flags setup as productivity oriented in which case Downloads app will be presented
              as Files app. Including showing of the Documents and "advanced" roots. -->
-    <bool name="productivity_device">true</bool>
+    <bool name="show_documents_root">true</bool>
 
 </resources>


### PR DESCRIPTION
The DocumentsUI overlay needs to be updated:

  * the DocumentsUI package moved from
    frameworks/base/packages/DocumentsUI
    to packages/apps/DocumentsUI

  * the tag "productivity_device" in res/values/config.xml
    has been renamed to "show_documents_root"

Change-Id: Id9028e5b92a98ac1f9fdb34cb5a0222be70d8596